### PR TITLE
feat: 토스트 컴포넌트 구현

### DIFF
--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -1,0 +1,15 @@
+import { ToastContainer, BodyText } from '../../styles/common/Toast';
+
+interface IToastProps {
+  bodyText: string;
+}
+
+const Toast = ({ bodyText }: IToastProps) => {
+  return (
+    <ToastContainer>
+      <BodyText>{bodyText}</BodyText>
+    </ToastContainer>
+  );
+};
+
+export default Toast;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,3 +5,4 @@ export { default as Dialog } from './common/Dialog/Dialog';
 export { default as LoginDialog } from './common/Dialog/LoginDialog';
 
 export { default as Popover } from './common/Popover/Popover';
+export { default as Toast } from './common/Toast';

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -1,10 +1,10 @@
-import { Popover } from '../components';
+import { Popover, Toast } from '../components';
 import styled from 'styled-components';
 
 const App = () => {
   return (
     <Container>
-      <Popover title="팝오버 타이틀" bodyText="팝오버 문장은 최대 3줄까지 입력 가능합니다." />
+      <Toast bodyText="토스트 메시지 내용" />
     </Container>
   );
 };

--- a/src/styles/common/Toast.ts
+++ b/src/styles/common/Toast.ts
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+import { semantic } from '../../styles/semantic';
+import { TYPO } from '../../styles/typo';
+
+const ToastContainer = styled.div`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  padding: 0.625rem 1.25rem;
+
+  border-radius: 0.75rem;
+  border: 1px solid ${semantic.light.border.transparent.neutral};
+  background: ${semantic.light.inversed.solid.background};
+
+  box-shadow:
+    0px 1.6px 5px 0px rgba(12, 10, 9, 0.1),
+    0px 4.2px 13.3px 0px rgba(12, 10, 9, 0.08),
+    0px 8px 24px 0px rgba(12, 10, 9, 0.06),
+    0px 24px 36px 0px rgba(12, 10, 9, 0.05),
+    0px 0px 8.6px 0px rgba(12, 10, 9, 0.09);
+`;
+
+const BodyText = styled.span`
+  text-align: center;
+
+  ${TYPO.body2}
+  color: ${semantic.light.inversed.solid.primary};
+`;
+
+export { ToastContainer, BodyText };


### PR DESCRIPTION
## 📌 작업 내용

> figma에 정의되어 있는 component 중 toast 컴포넌트 구현을 진행했습니다.

## 📌 구현 결과 (선택)

<img width="223" alt="스크린샷 2024-07-23 오후 1 38 51" src="https://github.com/user-attachments/assets/6ac8be95-4448-4f6d-8905-7d91c2485704">

## 📌 기타 사항

### ⚡️ 토스트 컴포넌트 사용 방법

```tsx
import { Toast } from '../components';

const App = () => {
  return (
    <Container>
      <Toast bodyText="토스트 메시지 내용" />
    </Container>
  );
};

export default App;
```

issue: #12 